### PR TITLE
:white_check_mark: add tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,10 @@
+def infra
+
+node(){
+  checkout scm
+
+  infra = load '/var/lib/jenkins/workspace/itop-test-infra_master/src/Infra.groovy'
+}
+
+
+infra.call()

--- a/src/Service/AIService.php
+++ b/src/Service/AIService.php
@@ -132,7 +132,7 @@ class AIService
 	}
 
 	/**
-	 * @param $sMessage The prompt
+	 * @param string $sMessage The prompt
 	 * @param string $sSystemInstruction The system prompt
 	 * @return string
 	 * @throws AIResponseException

--- a/tests/ci_description.ini
+++ b/tests/ci_description.ini
@@ -1,0 +1,35 @@
+[extension]
+; in case of behat tests required, iTopVersionToTest will be replaced at least by iTop from develop.
+; (debug option) used before declaring your extension in factory to retrieve it from git.
+extension_providedfromgit = 'true'
+
+[itop]
+;itop_branch: when not provided by default develop.
+itop_branch = support/3.2
+
+;itop_target_uri: use to launch ci from a factory target
+;itop_target_uri="type=build&item=iTop-SaaS-Free&version=3.0.2"
+
+;itop_setup=tests/setup_params/install.xml
+
+#itop_backup=tests/backups/itop-backup.tar.gz
+
+[itop_modules]
+;declare which components to install from github with current project during setup
+;itop_module[]=https://github.com/Combodo/combodo-my-account
+
+[behat]
+run_behat = false
+; when empty behat_feature_test => no behat test performed
+;behat_feature_test[]=tests/features/searchfilter.feature
+;behat_csv_folder[]=tests/csv-data/searchfilter
+
+[phpunit]
+; when empty phpunit_xml => no phpunit test performed
+; phpunit xml file description. required for phpunit testing
+phpunit_xml = tests/php-unit-tests/phpunit.xml
+
+; by default all tests if not provided
+phpunit_suite[] = Unitary
+
+php_version = 8.3-apache

--- a/tests/php-unit-tests/README.md
+++ b/tests/php-unit-tests/README.md
@@ -1,0 +1,8 @@
+# PHP unitary tests
+
+## Where should I add my test?
+
+- Covers an iTop PHP class or method?
+    - Most likely in "unitary-tests".
+- Covers the consistency of some data through the app?
+    - Most likely in "integration-tests".

--- a/tests/php-unit-tests/integration-tests/OllamaServiceTest.php
+++ b/tests/php-unit-tests/integration-tests/OllamaServiceTest.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Itomig\iTop\AiBase\Test;
+
+use Combodo\iTop\Test\UnitTest\ItopTestCase;
+use Itomig\iTop\Extension\AIBase\Engine\OllamaAIEngine;
+
+class OllamaServiceTest extends ItopTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->RequireOnceItopFile('/env-production/itomig-ai-base/vendor/autoload.php');
+	}
+
+	public function testOllamaServiceGetCompletion(): void // not consistent test but just for example purposes
+	{
+		$oOllamaService = new OllamaAIEngine('http://127.0.0.1:11434/api/', '', 'deepseek-r1:1.5b');
+		$sCompletion = $oOllamaService->GetCompletion('Translate this sentence : "Hello !"', 'You are french and you are translating english sentences to French.');
+		var_dump($sCompletion);
+		static::assertStringContainsString('Bonjour', $sCompletion);
+	}
+}

--- a/tests/php-unit-tests/phpunit.xml
+++ b/tests/php-unit-tests/phpunit.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+        bootstrap="../unittestautoload.php"
+        backupGlobals="true"
+        colors="true"
+        columns="120"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        processIsolation="false"
+        stopOnError="false"
+        stopOnFailure="false"
+        stopOnIncomplete="false"
+        stopOnRisky="false"
+        stopOnSkipped="false"
+        verbose="true"
+        printerClass="\Sempro\PHPUnitPrettyPrinter\PrettyPrinterForPhpUnit9"
+>
+
+  <php>
+    <ini name="error_reporting" value="E_ALL"/>
+    <ini name="display_errors" value="On"/>
+    <ini name="log_errors" value="On"/>
+    <ini name="html_errors" value="Off"/>
+    <env name="PHPUNIT_PRETTY_PRINT_PROGRESS" value="true"/>
+  </php>
+
+  <testsuites>
+    <testsuite name="Unitary">
+      <directory suffix="Test.php">unitary-tests</directory>
+    </testsuite>
+    <testsuite name="Integration">
+      <directory suffix="Test.php">integration-tests</directory>
+    </testsuite>
+  </testsuites>
+
+</phpunit>

--- a/tests/php-unit-tests/unitary-tests/AiBaseServiceTest.php
+++ b/tests/php-unit-tests/unitary-tests/AiBaseServiceTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Itomig\iTop\AiBase\Test;
+
+use Combodo\iTop\Test\UnitTest\ItopTestCase;
+use Itomig\iTop\Extension\AIBase\Engine\iAIEngineInterface;
+use Itomig\iTop\Extension\AIBase\Service\AIService;
+
+class AiBaseServiceTest extends ItopTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->RequireOnceItopFile('/env-production/itomig-ai-base/vendor/autoload.php');
+	}
+
+	public function testGetCompletion(): void
+	{
+		$oAIEngineInterfaceMock = $this->createMock(iAIEngineInterface::class);
+		$oAIEngineInterfaceMock->expects(static::once())
+			->method('getCompletion')
+			->willReturn('<think>Here is my reasoning</think>Mocked response');
+
+		$oAIService = new AIService($oAIEngineInterfaceMock);
+		$sCompletion = $oAIService->GetCompletion('This is a test prompt', 'ok');
+		static::assertEquals('Mocked response', $sCompletion); // no more think tag, cleaned up by AIService::GetCompletion
+	}
+}


### PR DESCRIPTION
This PR aims to add one example of unit test and one example of "integration" test.

There is also the necessary configuration to make the tests run automatically on Combodo's CI when there is a push on Combodo's fork. Only unit tests are run automatically. 