### PR TITLE
Make GetAIEngineClass() public for external extensions

### DIFF
--- a/src/Service/AIService.php
+++ b/src/Service/AIService.php
@@ -169,7 +169,7 @@ class AIService
 	 * @return class-string<iAIEngineInterface>|'' The class name of the AI engine, or null if no engine is configured.
 	 * @throws \ReflectionException
 	 */
-	protected static function GetAIEngineClass(string $sAIEngineName)
+	public static function GetAIEngineClass(string $sAIEngineName)
 	{
 		$sDesiredAIEngineClass = '';
 		/** @var $aAIEngines */


### PR DESCRIPTION
## Summary

This is a proposal to address issue #9 by making the `GetAIEngineClass()` method in `AIService` public, allowing external extensions to instantiate AI engines without code duplication.

## Problem

External extensions (like [combodo-oql-generator](https://github.com/Combodo/combodo-oql-generator/blob/master/src/Factory/AIEngineFactory.php)) currently need to duplicate the `GetAIEngineClass()` method because it is `protected` and not accessible from outside.

## Solution

Change method visibility from `protected` to `public`, enabling external extensions to reuse this functionality.

## Changes

- Changed `protected static function GetAIEngineClass()` to `public static function GetAIEngineClass()` in `src/Service/AIService.php`

## Non-Breaking Change

This should be a non-breaking change that only extends the API:
- Existing code should continue to work without modifications
- No behavior changes intended
- Only adds public accessibility to an existing method

However, a second pair of eyes to review this change is welcome to confirm there are no unintended side effects.

## Related

Fixes #9