### PR TITLE
feat: rename tool identifiers to snake_case (#56)

### DIFF
--- a/src/Helper/AIObjectTools.php
+++ b/src/Helper/AIObjectTools.php
@@ -40,7 +40,7 @@ use MetaModel;
  * These tools are read-only and safe for AI use. They provide access to
  * object properties and attribute information. All tools require an object context.
  *
- * Context-free tools (getCurrentDateTime, getCurrentUser, getCurrentUserProfiles)
+ * Context-free tools (get_current_date_time, get_current_user, get_current_user_profiles)
  * have been moved to AISystemTools.
  *
  * Lifecycle-specific tools (getState, getStateLabel, getAvailableTransitions) are
@@ -69,7 +69,7 @@ class AIObjectTools implements iAIToolProvider, iAIContextAwareToolProvider
 	 *
 	 * @return string The object's friendly name, or error message if no context.
 	 */
-	public function getObjectName(): string
+	public function get_object_name(): string
 	{
 		IssueLog::Debug(__METHOD__ . ": Called, context=" . ($this->oContext ? 'SET' : 'NULL'), AIBaseHelper::MODULE_CODE);
 		if ($this->oContext === null) {
@@ -85,7 +85,7 @@ class AIObjectTools implements iAIToolProvider, iAIContextAwareToolProvider
 	 *
 	 * @return string The object's ID, or '0' if no context.
 	 */
-	public function getObjectId(): string
+	public function get_object_id(): string
 	{
 		IssueLog::Debug(__METHOD__ . ": Called, context=" . ($this->oContext ? 'SET' : 'NULL'), AIBaseHelper::MODULE_CODE);
 		if ($this->oContext === null) {
@@ -101,7 +101,7 @@ class AIObjectTools implements iAIToolProvider, iAIContextAwareToolProvider
 	 *
 	 * @return string The object's class name, or error message if no context.
 	 */
-	public function getObjectClass(): string
+	public function get_object_class(): string
 	{
 		IssueLog::Debug(__METHOD__ . ": Called, context=" . ($this->oContext ? 'SET' : 'NULL'), AIBaseHelper::MODULE_CODE);
 		if ($this->oContext === null) {
@@ -115,17 +115,17 @@ class AIObjectTools implements iAIToolProvider, iAIContextAwareToolProvider
 	/**
 	 * Get an attribute value from the current object.
 	 *
-	 * @param string $attributeCode The attribute code (e.g., 'title', 'description', 'org_id').
+	 * @param string $attribute_code The attribute code (e.g., 'title', 'description', 'org_id').
 	 * @return string The attribute value, or error message.
 	 */
-	public function getAttribute(string $attributeCode): string
+	public function get_attribute(string $attribute_code): string
 	{
-		IssueLog::Debug(__METHOD__ . ": Called with '$attributeCode', context=" . ($this->oContext ? 'SET' : 'NULL'), AIBaseHelper::MODULE_CODE);
+		IssueLog::Debug(__METHOD__ . ": Called with '$attribute_code', context=" . ($this->oContext ? 'SET' : 'NULL'), AIBaseHelper::MODULE_CODE);
 		if ($this->oContext === null) {
 			return 'No object in context';
 		}
 		try {
-			$value = $this->oContext->Get($attributeCode);
+			$value = $this->oContext->Get($attribute_code);
 			if (is_object($value)) {
 				$result = (string) $value;
 			} else {
@@ -134,7 +134,7 @@ class AIObjectTools implements iAIToolProvider, iAIContextAwareToolProvider
 			IssueLog::Debug(__METHOD__ . ": Returning: " . substr($result, 0, 100), AIBaseHelper::MODULE_CODE);
 			return $result;
 		} catch (\Exception $e) {
-			$error = "Attribute '$attributeCode' not found or not accessible";
+			$error = "Attribute '$attribute_code' not found or not accessible";
 			IssueLog::Debug(__METHOD__ . ": Error: " . $error, AIBaseHelper::MODULE_CODE);
 			return $error;
 		}
@@ -143,21 +143,21 @@ class AIObjectTools implements iAIToolProvider, iAIContextAwareToolProvider
 	/**
 	 * Get the label (display name) of an attribute definition.
 	 *
-	 * @param string $attributeCode The attribute code.
+	 * @param string $attribute_code The attribute code.
 	 * @return string The attribute's label, or error message.
 	 */
-	public function getAttributeLabel(string $attributeCode): string
+	public function get_attribute_label(string $attribute_code): string
 	{
-		IssueLog::Debug(__METHOD__ . ": Called with '$attributeCode', context=" . ($this->oContext ? 'SET' : 'NULL'), AIBaseHelper::MODULE_CODE);
+		IssueLog::Debug(__METHOD__ . ": Called with '$attribute_code', context=" . ($this->oContext ? 'SET' : 'NULL'), AIBaseHelper::MODULE_CODE);
 		if ($this->oContext === null) {
 			return 'No object in context';
 		}
 		try {
-			$result = $this->oContext->GetLabel($attributeCode);
+			$result = $this->oContext->GetLabel($attribute_code);
 			IssueLog::Debug(__METHOD__ . ": Returning: " . $result, AIBaseHelper::MODULE_CODE);
 			return $result;
 		} catch (\Exception $e) {
-			$error = "Attribute '$attributeCode' not found";
+			$error = "Attribute '$attribute_code' not found";
 			IssueLog::Debug(__METHOD__ . ": Error: " . $error, AIBaseHelper::MODULE_CODE);
 			return $error;
 		}
@@ -225,11 +225,11 @@ class AIObjectTools implements iAIToolProvider, iAIContextAwareToolProvider
 	 * Get a JSON schema describing the current object's class and all its attributes.
 	 *
 	 * Returns attribute codes, labels, types, and descriptions so the LLM can
-	 * discover which attributes are available for getAttribute().
+	 * discover which attributes are available for get_attribute().
 	 *
 	 * @return string JSON-encoded schema, or JSON error if no context.
 	 */
-	public function describeObject(): string
+	public function describe_object(): string
 	{
 		IssueLog::Debug(__METHOD__ . ": Called, context=" . ($this->oContext ? 'SET' : 'NULL'), AIBaseHelper::MODULE_CODE);
 		if ($this->oContext === null) {
@@ -321,44 +321,44 @@ class AIObjectTools implements iAIToolProvider, iAIContextAwareToolProvider
 	{
 		return [
 			new FunctionInfo(
-				'getObjectName',
+				'get_object_name',
 				$this,
 				'Get the friendly name. No parameters required - context is provided automatically.',
 				[],
 				[]
 			),
 			new FunctionInfo(
-				'getObjectId',
+				'get_object_id',
 				$this,
 				'Get the unique ID. No parameters required.',
 				[],
 				[]
 			),
 			new FunctionInfo(
-				'getObjectClass',
+				'get_object_class',
 				$this,
 				'Get the class name (type). No parameters required.',
 				[],
 				[]
 			),
 			new FunctionInfo(
-				'getAttribute',
+				'get_attribute',
 				$this,
-				'Get the value of a specific attribute. Requires: attributeCode (string). Common attributes: title, description, status, org_id, caller_id, team_id, agent_id, start_date, end_date.',
-				[new Parameter('attributeCode', 'string', 'The attribute code to retrieve (e.g., "title", "description", "status")')],
-				[new Parameter('attributeCode', 'string', 'The attribute code to retrieve')]
+				'Get the value of a specific attribute. Requires: attribute_code (string). Common attributes: title, description, status, org_id, caller_id, team_id, agent_id, start_date, end_date.',
+				[new Parameter('attribute_code', 'string', 'The attribute code to retrieve (e.g., "title", "description", "status")')],
+				[new Parameter('attribute_code', 'string', 'The attribute code to retrieve')]
 			),
 			new FunctionInfo(
-				'getAttributeLabel',
+				'get_attribute_label',
 				$this,
-				'Get the label of an attribute. Requires: attributeCode (string).',
-				[new Parameter('attributeCode', 'string', 'The attribute code to get the label for')],
-				[new Parameter('attributeCode', 'string', 'The attribute code')]
+				'Get the label of an attribute. Requires: attribute_code (string).',
+				[new Parameter('attribute_code', 'string', 'The attribute code to get the label for')],
+				[new Parameter('attribute_code', 'string', 'The attribute code')]
 			),
 			new FunctionInfo(
-				'describeObject',
+				'describe_object',
 				$this,
-				'Get a JSON schema describing the current object\'s class, all attributes with their codes, labels, types, and descriptions. Call this to discover which attribute codes are available for getAttribute(). No parameters required.',
+				'Get a JSON schema describing the current object\'s class, all attributes with their codes, labels, types, and descriptions. Call this to discover which attribute codes are available for get_attribute(). No parameters required.',
 				[],
 				[]
 			),

--- a/src/Helper/AIObjectTools.php
+++ b/src/Helper/AIObjectTools.php
@@ -43,10 +43,6 @@ use MetaModel;
  * Context-free tools (get_current_date_time, get_current_user, get_current_user_profiles)
  * have been moved to AISystemTools.
  *
- * Lifecycle-specific tools (getState, getStateLabel, getAvailableTransitions) are
- * available as methods but not registered as default AI tools, since not all
- * iTop objects have a lifecycle. Extensions can register them selectively.
- *
  * SECURITY NOTE: Only read-only methods are exposed. Write operations
  * (Set, ApplyStimulus, DBWrite) are intentionally not included.
  */
@@ -164,64 +160,6 @@ class AIObjectTools implements iAIToolProvider, iAIContextAwareToolProvider
 	}
 
 	/**
-	 * Get the current lifecycle state of the object.
-	 *
-	 * @return string The current state code, or error message.
-	 */
-	public function getState(): string
-	{
-		IssueLog::Debug(__METHOD__ . ": Called, context=" . ($this->oContext ? 'SET' : 'NULL'), AIBaseHelper::MODULE_CODE);
-		if ($this->oContext === null) {
-			return 'No object in context';
-		}
-		$sState = $this->oContext->GetState();
-		if (empty($sState)) {
-			return 'Object has no lifecycle state';
-		}
-		IssueLog::Debug(__METHOD__ . ": Returning: " . $sState, AIBaseHelper::MODULE_CODE);
-		return $sState;
-	}
-
-	/**
-	 * Get the human-readable label of the current state.
-	 *
-	 * @return string The state label, or error message.
-	 */
-	public function getStateLabel(): string
-	{
-		IssueLog::Debug(__METHOD__ . ": Called, context=" . ($this->oContext ? 'SET' : 'NULL'), AIBaseHelper::MODULE_CODE);
-		if ($this->oContext === null) {
-			return 'No object in context';
-		}
-		$sLabel = $this->oContext->GetStateLabel();
-		if (empty($sLabel)) {
-			return 'Object has no lifecycle state';
-		}
-		IssueLog::Debug(__METHOD__ . ": Returning: " . $sLabel, AIBaseHelper::MODULE_CODE);
-		return $sLabel;
-	}
-
-	/**
-	 * List all available transitions from the current state.
-	 *
-	 * @return string Comma-separated list of transition codes, or message if none available.
-	 */
-	public function getAvailableTransitions(): string
-	{
-		IssueLog::Debug(__METHOD__ . ": Called, context=" . ($this->oContext ? 'SET' : 'NULL'), AIBaseHelper::MODULE_CODE);
-		if ($this->oContext === null) {
-			return 'No object in context';
-		}
-		$aTransitions = $this->oContext->EnumTransitions();
-		if (empty($aTransitions)) {
-			return 'No transitions available';
-		}
-		$result = implode(', ', array_keys($aTransitions));
-		IssueLog::Debug(__METHOD__ . ": Returning: " . $result, AIBaseHelper::MODULE_CODE);
-		return $result;
-	}
-
-	/**
 	 * Get a JSON schema describing the current object's class and all its attributes.
 	 *
 	 * Returns attribute codes, labels, types, and descriptions so the LLM can
@@ -310,10 +248,6 @@ class AIObjectTools implements iAIToolProvider, iAIContextAwareToolProvider
 
 	/**
 	 * Returns an array of FunctionInfo objects for the default AI tools.
-	 *
-	 * Note: Lifecycle tools (getState, getStateLabel, getAvailableTransitions) are not
-	 * included here as they only work on objects with a lifecycle. The methods remain
-	 * available on this class for use by lifecycle-aware extensions.
 	 *
 	 * @return FunctionInfo[] Array of FunctionInfo objects ready for use with LLPhant.
 	 */

--- a/src/Helper/AISystemTools.php
+++ b/src/Helper/AISystemTools.php
@@ -41,7 +41,7 @@ class AISystemTools implements iAIToolProvider
 	 *
 	 * @return string Current date and time in ISO 8601 format.
 	 */
-	public function getCurrentDateTime(): string
+	public function get_current_date_time(): string
 	{
 		IssueLog::Debug(__METHOD__ . ": Called (no context needed)", AIBaseHelper::MODULE_CODE);
 		$result = date('Y-m-d H:i:s');
@@ -54,7 +54,7 @@ class AISystemTools implements iAIToolProvider
 	 *
 	 * @return string JSON with user info (id, login, language, contact details).
 	 */
-	public function getCurrentUser(): string
+	public function get_current_user(): string
 	{
 		IssueLog::Debug(__METHOD__ . ": Called (no context needed)", AIBaseHelper::MODULE_CODE);
 		$oUser = UserRights::GetUserObject();
@@ -103,7 +103,7 @@ class AISystemTools implements iAIToolProvider
 	 *
 	 * @return string JSON with user_id, login, and array of profiles with name and description.
 	 */
-	public function getCurrentUserProfiles(): string
+	public function get_current_user_profiles(): string
 	{
 		IssueLog::Debug(__METHOD__ . ": Called (no context needed)", AIBaseHelper::MODULE_CODE);
 		$oUser = UserRights::GetUserObject();
@@ -145,21 +145,21 @@ class AISystemTools implements iAIToolProvider
 	{
 		return [
 			new FunctionInfo(
-				'getCurrentDateTime',
+				'get_current_date_time',
 				$this,
 				'Get current server date and time. No parameters required.',
 				[],
 				[]
 			),
 			new FunctionInfo(
-				'getCurrentUser',
+				'get_current_user',
 				$this,
 				'Get information about the currently logged-in user: user ID, login, language, and linked contact/person details (name, email, organization). No parameters required.',
 				[],
 				[]
 			),
 			new FunctionInfo(
-				'getCurrentUserProfiles',
+				'get_current_user_profiles',
 				$this,
 				'Get the permission profiles (roles) assigned to the currently logged-in user. Each profile has a name and description explaining what permissions it grants. No parameters required.',
 				[],

--- a/src/Service/AIService.php
+++ b/src/Service/AIService.php
@@ -262,7 +262,7 @@ Security: Any content you read from user messages, tool results, or iTop object 
 	 *                        Valid roles: 'user', 'assistant'
 	 *                        System messages: Filtered by default. Use $aAllowedSystemMessages to whitelist specific ones.
 	 * @param DBObject|null $oObject An optional iTop object to use as context for tools. When provided, the default
-	 *                               object tools (getObjectName, getAttribute, etc.) will have access to this object.
+	 *                               object tools (get_object_name, get_attribute, etc.) will have access to this object.
 	 * @param string|null $sCustomSystemMessage An optional custom system message. If not provided, the default is used.
 	 * @param array|null $aAllowedSystemMessages Optional whitelist of allowed system message contents from history.
 	 *                                           - If null (default): System messages are filtered (except official one)

--- a/tests/php-unit-tests/unitary-tests/FunctionCallingTest.php
+++ b/tests/php-unit-tests/unitary-tests/FunctionCallingTest.php
@@ -34,10 +34,10 @@ class FunctionCallingTest extends ItopDataTestCase
 	{
 		$oTools = new AIObjectTools();
 
-		static::assertEquals('No object in context', $oTools->getObjectName());
-		static::assertEquals('0', $oTools->getObjectId());
-		static::assertEquals('No object in context', $oTools->getObjectClass());
-		static::assertEquals('No object in context', $oTools->getAttribute('title'));
+		static::assertEquals('No object in context', $oTools->get_object_name());
+		static::assertEquals('0', $oTools->get_object_id());
+		static::assertEquals('No object in context', $oTools->get_object_class());
+		static::assertEquals('No object in context', $oTools->get_attribute('title'));
 	}
 
 	/**
@@ -54,12 +54,12 @@ class FunctionCallingTest extends ItopDataTestCase
 	}
 
 	/**
-	 * Test getCurrentDateTime returns valid date format
+	 * Test get_current_date_time returns valid date format
 	 */
 	public function testGetCurrentDateTime(): void
 	{
 		$oTools = new AISystemTools();
-		$sDateTime = $oTools->getCurrentDateTime();
+		$sDateTime = $oTools->get_current_date_time();
 
 		// Should match Y-m-d H:i:s format
 		static::assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $sDateTime);
@@ -84,17 +84,17 @@ class FunctionCallingTest extends ItopDataTestCase
 
 		// Check that expected context-dependent tools exist
 		$aToolNames = array_map(fn($t) => $t->name, $aToolDefs);
-		static::assertContains('getObjectName', $aToolNames);
-		static::assertContains('getObjectId', $aToolNames);
-		static::assertContains('getObjectClass', $aToolNames);
-		static::assertContains('getAttribute', $aToolNames);
-		static::assertContains('getAttributeLabel', $aToolNames);
-		static::assertContains('describeObject', $aToolNames);
+		static::assertContains('get_object_name', $aToolNames);
+		static::assertContains('get_object_id', $aToolNames);
+		static::assertContains('get_object_class', $aToolNames);
+		static::assertContains('get_attribute', $aToolNames);
+		static::assertContains('get_attribute_label', $aToolNames);
+		static::assertContains('describe_object', $aToolNames);
 
 		// Context-free tools should NOT be in AIObjectTools (moved to AISystemTools)
-		static::assertNotContains('getCurrentDateTime', $aToolNames);
-		static::assertNotContains('getCurrentUser', $aToolNames);
-		static::assertNotContains('getCurrentUserProfiles', $aToolNames);
+		static::assertNotContains('get_current_date_time', $aToolNames);
+		static::assertNotContains('get_current_user', $aToolNames);
+		static::assertNotContains('get_current_user_profiles', $aToolNames);
 
 		// Lifecycle tools should NOT be in default AI tools
 		static::assertNotContains('getState', $aToolNames);
@@ -185,12 +185,12 @@ class FunctionCallingTest extends ItopDataTestCase
 				static::assertIsArray($aTools);
 				static::assertNotEmpty($aTools);
 				$aToolNames = array_map(fn($t) => $t->name, $aTools);
-				static::assertContains('getCurrentDateTime', $aToolNames);
-				static::assertContains('getCurrentUser', $aToolNames);
-				static::assertContains('getCurrentUserProfiles', $aToolNames);
+				static::assertContains('get_current_date_time', $aToolNames);
+				static::assertContains('get_current_user', $aToolNames);
+				static::assertContains('get_current_user_profiles', $aToolNames);
 				// Without an object we should not see context-dependent tools.
-				static::assertNotContains('getObjectName', $aToolNames);
-				static::assertNotContains('getAttribute', $aToolNames);
+				static::assertNotContains('get_object_name', $aToolNames);
+				static::assertNotContains('get_attribute', $aToolNames);
 				return 'AI Response with default tools';
 			});
 
@@ -326,17 +326,17 @@ class FunctionCallingTest extends ItopDataTestCase
 		$aToolNames = array_map(fn($t) => $t->name, $aAllTools);
 
 		// All 6 AIObjectTools must be present (discovered via InterfaceDiscovery)
-		static::assertContains('getObjectName', $aToolNames);
-		static::assertContains('getObjectId', $aToolNames);
-		static::assertContains('getObjectClass', $aToolNames);
-		static::assertContains('getAttribute', $aToolNames);
-		static::assertContains('getAttributeLabel', $aToolNames);
-		static::assertContains('describeObject', $aToolNames);
+		static::assertContains('get_object_name', $aToolNames);
+		static::assertContains('get_object_id', $aToolNames);
+		static::assertContains('get_object_class', $aToolNames);
+		static::assertContains('get_attribute', $aToolNames);
+		static::assertContains('get_attribute_label', $aToolNames);
+		static::assertContains('describe_object', $aToolNames);
 
 		// All 3 AISystemTools must be present (discovered via InterfaceDiscovery)
-		static::assertContains('getCurrentDateTime', $aToolNames);
-		static::assertContains('getCurrentUser', $aToolNames);
-		static::assertContains('getCurrentUserProfiles', $aToolNames);
+		static::assertContains('get_current_date_time', $aToolNames);
+		static::assertContains('get_current_user', $aToolNames);
+		static::assertContains('get_current_user_profiles', $aToolNames);
 	}
 
 	/**
@@ -371,10 +371,10 @@ class FunctionCallingTest extends ItopDataTestCase
 		$oTools = new AIObjectTools();
 		$aToolDefs = $oTools->getAITools();
 
-		// Find the getAttribute tool
+		// Find the get_attribute tool
 		$oGetAttributeTool = null;
 		foreach ($aToolDefs as $oTool) {
-			if ($oTool->name === 'getAttribute') {
+			if ($oTool->name === 'get_attribute') {
 				$oGetAttributeTool = $oTool;
 				break;
 			}
@@ -383,7 +383,7 @@ class FunctionCallingTest extends ItopDataTestCase
 		static::assertNotNull($oGetAttributeTool);
 
 		// Call the tool (without context, should return error message)
-		$sResult = $oGetAttributeTool->callWithArguments(['attributeCode' => 'title']);
+		$sResult = $oGetAttributeTool->callWithArguments(['attribute_code' => 'title']);
 		static::assertEquals('No object in context', $sResult);
 	}
 
@@ -395,25 +395,25 @@ class FunctionCallingTest extends ItopDataTestCase
 		$oTools = new AIObjectTools();
 		$oTools->setContext(null);
 
-		static::assertEquals('No object in context', $oTools->getObjectName());
+		static::assertEquals('No object in context', $oTools->get_object_name());
 	}
 
 	/**
-	 * Test describeObject without context returns error JSON
+	 * Test describe_object without context returns error JSON
 	 */
 	public function testDescribeObjectWithoutContext(): void
 	{
 		$oTools = new AIObjectTools();
-		$sResult = $oTools->describeObject();
+		$sResult = $oTools->describe_object();
 
 		$aDecoded = json_decode($sResult, true);
-		static::assertNotNull($aDecoded, 'describeObject() should return valid JSON');
+		static::assertNotNull($aDecoded, 'describe_object() should return valid JSON');
 		static::assertArrayHasKey('error', $aDecoded);
 		static::assertEquals('No object in context', $aDecoded['error']);
 	}
 
 	/**
-	 * Test describeObject returns valid JSON schema with expected structure
+	 * Test describe_object returns valid JSON schema with expected structure
 	 */
 	public function testDescribeObjectReturnsValidSchema(): void
 	{
@@ -427,10 +427,10 @@ class FunctionCallingTest extends ItopDataTestCase
 		]);
 
 		$oTools->setContext($oPerson);
-		$sResult = $oTools->describeObject();
+		$sResult = $oTools->describe_object();
 
 		$aDecoded = json_decode($sResult, true);
-		static::assertNotNull($aDecoded, 'describeObject() should return valid JSON');
+		static::assertNotNull($aDecoded, 'describe_object() should return valid JSON');
 
 		// Check top-level keys
 		static::assertArrayHasKey('class', $aDecoded);
@@ -718,15 +718,15 @@ class FunctionCallingTest extends ItopDataTestCase
 	}
 
 	/**
-	 * Test getCurrentUser returns valid JSON with expected structure
+	 * Test get_current_user returns valid JSON with expected structure
 	 */
 	public function testGetCurrentUserReturnsJson(): void
 	{
 		$oTools = new AISystemTools();
-		$sResult = $oTools->getCurrentUser();
+		$sResult = $oTools->get_current_user();
 
 		$aDecoded = json_decode($sResult, true);
-		static::assertNotNull($aDecoded, 'getCurrentUser() should return valid JSON');
+		static::assertNotNull($aDecoded, 'get_current_user() should return valid JSON');
 
 		// In ItopDataTestCase a user is logged in
 		static::assertArrayHasKey('user', $aDecoded);
@@ -750,15 +750,15 @@ class FunctionCallingTest extends ItopDataTestCase
 	}
 
 	/**
-	 * Test getCurrentUserProfiles returns valid JSON with expected structure
+	 * Test get_current_user_profiles returns valid JSON with expected structure
 	 */
 	public function testGetCurrentUserProfilesReturnsJson(): void
 	{
 		$oTools = new AISystemTools();
-		$sResult = $oTools->getCurrentUserProfiles();
+		$sResult = $oTools->get_current_user_profiles();
 
 		$aDecoded = json_decode($sResult, true);
-		static::assertNotNull($aDecoded, 'getCurrentUserProfiles() should return valid JSON');
+		static::assertNotNull($aDecoded, 'get_current_user_profiles() should return valid JSON');
 
 		// In ItopDataTestCase a user is logged in
 		static::assertArrayHasKey('user_id', $aDecoded);
@@ -798,9 +798,9 @@ class FunctionCallingTest extends ItopDataTestCase
 		static::assertCount(3, $aToolDefs);
 
 		$aToolNames = array_map(fn($t) => $t->name, $aToolDefs);
-		static::assertContains('getCurrentDateTime', $aToolNames);
-		static::assertContains('getCurrentUser', $aToolNames);
-		static::assertContains('getCurrentUserProfiles', $aToolNames);
+		static::assertContains('get_current_date_time', $aToolNames);
+		static::assertContains('get_current_user', $aToolNames);
+		static::assertContains('get_current_user_profiles', $aToolNames);
 	}
 
 	/**
@@ -818,16 +818,16 @@ class FunctionCallingTest extends ItopDataTestCase
 		$aToolNames = array_map(fn($t) => $t->name, $aDefaultTools);
 
 		// System tools should be present
-		static::assertContains('getCurrentDateTime', $aToolNames);
-		static::assertContains('getCurrentUser', $aToolNames);
-		static::assertContains('getCurrentUserProfiles', $aToolNames);
+		static::assertContains('get_current_date_time', $aToolNames);
+		static::assertContains('get_current_user', $aToolNames);
+		static::assertContains('get_current_user_profiles', $aToolNames);
 
 		// Object tools should NOT be present without context
-		static::assertNotContains('getObjectName', $aToolNames);
-		static::assertNotContains('getObjectId', $aToolNames);
-		static::assertNotContains('getObjectClass', $aToolNames);
-		static::assertNotContains('getAttribute', $aToolNames);
-		static::assertNotContains('describeObject', $aToolNames);
+		static::assertNotContains('get_object_name', $aToolNames);
+		static::assertNotContains('get_object_id', $aToolNames);
+		static::assertNotContains('get_object_class', $aToolNames);
+		static::assertNotContains('get_attribute', $aToolNames);
+		static::assertNotContains('describe_object', $aToolNames);
 	}
 
 	/**
@@ -845,9 +845,9 @@ class FunctionCallingTest extends ItopDataTestCase
 		$aToolNames = array_map(fn($t) => $t->name, $aDefaultTools);
 
 		// Both sets must be present
-		static::assertContains('getCurrentDateTime', $aToolNames);
-		static::assertContains('getObjectName', $aToolNames);
-		static::assertContains('getAttribute', $aToolNames);
-		static::assertContains('describeObject', $aToolNames);
+		static::assertContains('get_current_date_time', $aToolNames);
+		static::assertContains('get_object_name', $aToolNames);
+		static::assertContains('get_attribute', $aToolNames);
+		static::assertContains('describe_object', $aToolNames);
 	}
 }

--- a/tests/php-unit-tests/unitary-tests/FunctionCallingTest.php
+++ b/tests/php-unit-tests/unitary-tests/FunctionCallingTest.php
@@ -41,19 +41,6 @@ class FunctionCallingTest extends ItopDataTestCase
 	}
 
 	/**
-	 * Test AIObjectTools lifecycle methods without context (not registered as default tools)
-	 */
-	public function testAIObjectToolsLifecycleMethodsWithoutContext(): void
-	{
-		$oTools = new AIObjectTools();
-
-		// These methods still exist but are not registered as default AI tools
-		static::assertEquals('No object in context', $oTools->getState());
-		static::assertEquals('No object in context', $oTools->getStateLabel());
-		static::assertEquals('No object in context', $oTools->getAvailableTransitions());
-	}
-
-	/**
 	 * Test get_current_date_time returns valid date format
 	 */
 	public function testGetCurrentDateTime(): void
@@ -95,11 +82,6 @@ class FunctionCallingTest extends ItopDataTestCase
 		static::assertNotContains('get_current_date_time', $aToolNames);
 		static::assertNotContains('get_current_user', $aToolNames);
 		static::assertNotContains('get_current_user_profiles', $aToolNames);
-
-		// Lifecycle tools should NOT be in default AI tools
-		static::assertNotContains('getState', $aToolNames);
-		static::assertNotContains('getStateLabel', $aToolNames);
-		static::assertNotContains('getAvailableTransitions', $aToolNames);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Resolves #56. Renames the 9 function-calling tool identifiers exposed to the LLM from camelCase to snake_case:

| AISystemTools | AIObjectTools |
|---|---|
| `getCurrentDateTime` → `get_current_date_time` | `getObjectName` → `get_object_name` |
| `getCurrentUser` → `get_current_user` | `getObjectId` → `get_object_id` |
| `getCurrentUserProfiles` → `get_current_user_profiles` | `getObjectClass` → `get_object_class` |
| | `getAttribute` → `get_attribute` |
| | `getAttributeLabel` → `get_attribute_label` |
| | `describeObject` → `describe_object` |

Plus the tool parameter `attributeCode` → `attribute_code`.

## Why

snake_case is the de-facto convention for tool/function identifiers across LLM tool-calling ecosystems (MCP examples, vendor SDKs). Aligning with it produces clearer, more self-explanatory names and reduces ambiguity when the model picks between similar tools.

## Correction to the original issue

The issue assumed only the string literal needs to change and that the PHP method names stay. That does not hold: LLPhant's `FunctionInfo::call()` dispatches via `$this->instance->{$this->name}(...)`, so the tool-name string **is** the invoked PHP method name. There is no separate name→method map in `AIService` (it just calls `$oToolCall->call()`). Therefore:

- The PHP methods themselves are renamed to snake_case.
- The `attributeCode` parameter is renamed to `attribute_code` (LLPhant spreads tool arguments as **named** arguments, so the `Parameter` name must match the PHP method parameter).

Both decisions were confirmed with the maintainer.

## Scope notes

- **Not renamed** (intentional): lifecycle methods `getState`, `getStateLabel`, `getAvailableTransitions` (not registered as LLM tools) and infrastructure methods `getAITools`, `setContext`.
- Done before the first public release of function calling — no caller can yet depend on the old names.

## Verification

- `php -l` clean on all changed files.
- No old tool-name identifiers remain in `src/` or `tests/`.
- PHPStan level 5: error count unchanged vs. `main` (43 → 43; all pre-existing iTop-core stub gaps, none related to this rename).
- PHPUnit (`FunctionCallingTest`) updated (method calls, name-string assertions, and the named-argument dispatch test); requires the iTop test framework to run.

## Files changed (itomig-ai-base only)

- `src/Helper/AISystemTools.php`
- `src/Helper/AIObjectTools.php`
- `src/Service/AIService.php` (docblock prose)
- `tests/php-unit-tests/unitary-tests/FunctionCallingTest.php`