### PR TITLE
Add image input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ public function ContinueConversation(
 Continues a multi-turn conversation by maintaining context across multiple exchanges with the AI, with optional function/tool calling.
 
 **Parameters:**
-- `$aHistory`: Array of conversation history. Each entry has `role` (user/assistant) and `content`
+- `$aHistory`: Array of conversation history. Each entry has `role` and `content`; user entries may also include an optional `images` list. Each image must contain raw base64 data in `data` and its MIME type in `media_type`.
 - `$oObject`: (Optional) iTop object context. When set, context-aware tool providers receive it via `setContext()`. Passing `$oObject` does **not** by itself attach any tools — see `$aTools`.
 - `$sCustomSystemMessage`: (Optional) Custom system message for this turn
 - `$aAllowedSystemMessages`: (Optional) Whitelist of allowed system messages from history

--- a/README.md
+++ b/README.md
@@ -96,6 +96,93 @@ You can use the OpenAI engine with compatible endpoints (e.g., Open-WebUI, Local
 ),
 ```
 
+### Image Input Support
+
+Multi-turn conversations can include image payloads on user messages by adding an `images` array to a user history entry.
+
+Each image entry must contain raw base64 data and a MIME media type:
+
+```php
+array(
+    'role' => 'user',
+    'content' => 'Describe this screenshot.',
+    'images' => array(
+        array(
+            'data' => $sBase64ImageData,
+            'media_type' => 'image/png',
+        ),
+    ),
+)
+```
+
+Do not include the `data:image/png;base64,` prefix in `data` when calling ai-base directly. If you receive a browser data URL, strip the prefix first:
+
+```php
+$sImageData = preg_replace('/^data:[^;]+;base64,/i', '', $sBrowserDataUrl);
+$sImageData = preg_replace('/\s+/', '', $sImageData);
+```
+
+The recommended media types are:
+
+```php
+array('image/png', 'image/jpeg', 'image/gif', 'image/webp')
+```
+
+`image/jpg` should be normalized to `image/jpeg`. Invalid base64, unsupported media types, and oversized uploads should be rejected by the caller before invoking ai-base. An 8 MB decoded-image limit is a reasonable default for upload validation.
+
+Minimal direct usage with `AIService`:
+
+```php
+$aHistory = array(
+    array(
+        'role' => 'user',
+        'content' => 'What problem is visible in this screenshot?',
+        'images' => array(
+            array(
+                'data' => $sBase64ImageData,
+                'media_type' => 'image/png',
+            ),
+        ),
+    ),
+);
+
+$oService = new AIService();
+$aResult = $oService->ContinueConversation($aHistory);
+$sAnswer = $aResult['response'];
+```
+
+Typical application-level usage is to build the user entry only when images are present:
+
+```php
+$aUserEntry = array(
+    'role' => 'user',
+    'content' => $sUserMessage,
+);
+
+if (!empty($aImages)) {
+    $aUserEntry['images'] = $aImages;
+}
+
+$oConversationStatus->appendHistoryEntries(array($aUserEntry));
+```
+
+When images are extracted from HTML or another source, convert each image into the same payload shape and attach the deduplicated list to the user turn:
+
+```php
+$aImages[] = array(
+    'data' => $sBase64ImageData,
+    'media_type' => 'image/jpeg',
+);
+```
+
+Image input is available only for engines implementing `iAIVisionEngine`. The current vision-capable engines are `OpenAI` and `AnthropicAI`. Engines that do not implement that interface, such as `MistralAI` and `OllamaAI`, fail locally before any provider request with this configuration error:
+
+```text
+The configured AI engine does not support image input.
+```
+
+For OpenAI-compatible endpoints, ai-base can only verify that the selected engine adapter supports vision messages. It cannot know whether the configured backend model actually accepts images. If an OpenAI-compatible model is text-only, the request is sent and the provider response is surfaced as an AI engine error, usually an HTTP 400-style error from the backend. Configure a vision-capable model when using image input.
+
 ### Custom System Prompts Configuration
 
 The extension comes with default system prompts for common tasks. You can override these with custom instructions to influence the behavior of your chosen AI engine and LLM:

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Image input is available only for engines implementing `iAIVisionEngine`. The cu
 The configured AI engine does not support image input.
 ```
 
-For OpenAI-compatible endpoints, ai-base can only verify that the selected engine adapter supports vision messages. It cannot know whether the configured backend model actually accepts images. If an OpenAI-compatible model is text-only, the request is sent and the provider response is surfaced as an AI engine error, usually an HTTP 400-style error from the backend. Configure a vision-capable model when using image input.
+For OpenAI-compatible endpoints, ai-base can only verify that the selected engine adapter supports vision messages. It cannot know whether the configured backend model actually accepts images until the request is sent. If a text-only model rejects image input, responses such as `No endpoints found that support image input` are classified as `AIVisionUnsupportedException` with guidance to select a vision-capable model. Configure a vision-capable model when using image input.
 
 ### Custom System Prompts Configuration
 

--- a/module.itomig-ai-base.php
+++ b/module.itomig-ai-base.php
@@ -5,7 +5,7 @@
 
 SetupWebPage::AddModule(
 	__FILE__, // Path to the current file, all other file names are relative to the directory containing this file
-	'itomig-ai-base/26.1.1',
+	'itomig-ai-base/26.1.2',
 	array(
 		// Identification
 		//

--- a/src/Contracts/iAIVisionEngine.php
+++ b/src/Contracts/iAIVisionEngine.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ *  @copyright   Copyright (C) 2010-2026 Combodo SARL
+ *  @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Itomig\iTop\Extension\AIBase\Contracts;
+
+use LLPhant\Chat\Message;
+
+interface iAIVisionEngine
+{
+	/**
+	 * Creates a provider-compatible user message containing images.
+	 *
+	 * @param string $sContent
+	 * @param array<int, array{data: string, media_type: string}> $aImages
+	 */
+	public function CreateVisionMessage(
+		string $sContent,
+		array $aImages
+	): Message;
+}

--- a/src/Engine/AnthropicAIEngine.php
+++ b/src/Engine/AnthropicAIEngine.php
@@ -24,12 +24,17 @@
 namespace Itomig\iTop\Extension\AIBase\Engine;
 
 use GuzzleHttp\Exception\ConnectException;
+use Itomig\iTop\Extension\AIBase\Contracts\iAIVisionEngine;
 use Itomig\iTop\Extension\AIBase\Exception\AINetworkException;
 use LLPhant\AnthropicConfig;
+use LLPhant\Chat\Anthropic\AnthropicImage;
+use LLPhant\Chat\Anthropic\AnthropicImageType;
+use LLPhant\Chat\Anthropic\AnthropicVisionMessage;
 use LLPhant\Chat\AnthropicChat;
 use LLPhant\Chat\ChatInterface;
+use LLPhant\Chat\Message;
 
-class AnthropicAIEngine extends GenericAIEngine implements iAIEngineInterface
+class AnthropicAIEngine extends GenericAIEngine implements iAIEngineInterface, iAIVisionEngine
 {
 	/**
 	 * @inheritDoc
@@ -86,5 +91,41 @@ class AnthropicAIEngine extends GenericAIEngine implements iAIEngineInterface
 		$oConfig = new AnthropicConfig($this->model, 4096, array(), $this->apiKey);
 		$oChat = new AnthropicChat($oConfig);
 		return $oChat;
+	}
+
+	public function CreateVisionMessage(string $sContent, array $aImages): Message
+	{
+		$aAnthropicImages = [];
+
+		foreach ($aImages as $aImage) {
+			if (!is_array($aImage)) {
+				continue;
+			}
+
+			$sData = trim((string) ($aImage['data'] ?? ''));
+			$sMediaType = trim((string) ($aImage['media_type'] ?? ''));
+
+			if ($sData === '' || $sMediaType === '') {
+				continue;
+			}
+
+			try {
+				$aAnthropicImages[] = new AnthropicImage(
+					AnthropicImageType::from($sMediaType),
+					$sData
+				);
+			} catch (\ValueError|\InvalidArgumentException $e) {
+				continue;
+			}
+		}
+
+		if ($aAnthropicImages === []) {
+			return Message::user($sContent);
+		}
+
+		return new AnthropicVisionMessage(
+			$aAnthropicImages,
+			$sContent
+		);
 	}
 }

--- a/src/Engine/GenericAIEngine.php
+++ b/src/Engine/GenericAIEngine.php
@@ -29,6 +29,7 @@ use Itomig\iTop\Extension\AIBase\Exception\AIContextWindowException;
 use Itomig\iTop\Extension\AIBase\Exception\AIEngineException;
 use Itomig\iTop\Extension\AIBase\Exception\AINetworkException;
 use Itomig\iTop\Extension\AIBase\Exception\AIRateLimitException;
+use Itomig\iTop\Extension\AIBase\Exception\AIVisionUnsupportedException;
 use Itomig\iTop\Extension\AIBase\Helper\AIBaseHelper;
 use LLPhant\Chat\ChatInterface;
 use LLPhant\Chat\Enums\ChatRole;
@@ -88,6 +89,13 @@ abstract class GenericAIEngine implements iAIEngineInterface
 		if ($iCode === 401 || $iCode === 403) {
 			return new AIAuthException($sMsg, $iCode, $e);
 		}
+		if ($this->isVisionUnsupportedMessage($sMsg)) {
+			return new AIVisionUnsupportedException(
+				'The configured AI model or endpoint does not support image input. Select a vision-capable model. Provider response: '.$sMsg,
+				$iCode,
+				$e
+			);
+		}
 		if ($iCode === 413) {
 			return new AIContextWindowException($sMsg, $iCode, $e);
 		}
@@ -102,6 +110,30 @@ abstract class GenericAIEngine implements iAIEngineInterface
 		}
 
 		return new AINetworkException($sMsg, $iCode, $e);
+	}
+
+	private function isVisionUnsupportedMessage(string $sMessage): bool
+	{
+		$sMessageLower = strtolower($sMessage);
+		$aUnsupportedVisionPatterns = [
+			'/\bno\s+(?:(?:available|compatible|matching)\s+)?endpoints?\b.{0,100}\b(?:image(?:s)?(?:[\s_-]+url|\s+inputs?)|visual(?:\s+inputs?)?|vision(?:\s+inputs?)?|multimodal(?:\s+inputs?)?)\b/',
+			'/\b(?:image(?:s)?(?:[\s_-]+url|\s+inputs?)|visual|vision|multimodal)(?:\s+\w+){0,5}\s+only\s+(?:supported|available|allowed|accepted)\s+(?:by|for|with)\b/',
+			'/\b(?:does\s+not|doesn\'t|cannot|can\'t|will\s+not|won\'t)\s+(?:support|accept|process|handle|allow|permit)\s+(?:the\s+)?(?:image(?:s)?(?:[\s_-]+url)?|visual|vision|multimodal)(?:\s+(?:inputs?|content(?:\s+blocks?)?|parts?|data))?\b/',
+			'/\b(?:image(?:s)?(?:[\s_-]+url)?|visual|vision|multimodal)(?:\s+(?:inputs?|content(?:\s+blocks?)?|parts?|data|modality|capabilit(?:y|ies)|models?)){0,2}\s+(?:is|are)?\s*(?:not\s+supported|unsupported|not\s+available|unavailable|not\s+allowed|not\s+accepted|not\s+permitted|not\s+compatible(?:\s+with)?|disabled|cannot\s+be\s+processed|can\'t\s+be\s+processed)\b/',
+			'/\b(?:model|endpoint|provider|engine|deployment)\b.{0,80}\b(?:not\s+multimodal|not\s+vision(?:[-\s]capable)?|not\s+(?:a\s+)?(?:vision|multimodal)\s+model|not\s+capable\s+of\s+(?:processing\s+)?(?:images?|visual\s+input|vision)|text[-\s]+only)\b/',
+			'/\b(?:model|endpoint|provider|engine|deployment)\b.{0,80}\b(?:only\s+(?:supports?|accepts?|handles?)\s+text|(?:supports?|accepts?|handles?)\s+text\s+only)\b/',
+			'/\bunsupported\s+(?:input\s+type|content\s+type)\s*:?\s*(?:image(?:s)?(?:[\s_-]+url)?|visual|vision|multimodal)\b/',
+			'/\bunsupported\s+(?:image(?:s)?(?:[\s_-]+url)?|visual|vision|multimodal)\s+inputs?\b/',
+			'/\b(?:does\s+not|doesn\'t)\s+have(?:\s+the)?\s+(?:image(?:s)?(?:[\s_-]+url)?|visual|vision|multimodal)(?:\s+(?:inputs?|content(?:\s+blocks?)?|parts?|data|modality|capabilit(?:y|ies)|support)){0,2}\b/',
+		];
+
+		foreach ($aUnsupportedVisionPatterns as $sPattern) {
+			if (preg_match($sPattern, $sMessageLower) === 1) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Engine/OpenAIEngine.php
+++ b/src/Engine/OpenAIEngine.php
@@ -25,12 +25,17 @@ namespace Itomig\iTop\Extension\AIBase\Engine;
 
 use GuzzleHttp\Exception\ConnectException;
 use IssueLog;
+use Itomig\iTop\Extension\AIBase\Contracts\iAIVisionEngine;
 use Itomig\iTop\Extension\AIBase\Exception\AINetworkException;
 use LLPhant\Chat\ChatInterface;
+use LLPhant\Chat\Message;
+use LLPhant\Chat\Vision\ImageQuality;
+use LLPhant\Chat\Vision\ImageSource;
+use LLPhant\Chat\Vision\VisionMessage;
 use LLPhant\OpenAIConfig;
 use LLPhant\Chat\OpenAIChat;
 
-class OpenAIEngine extends GenericAIEngine implements iAIEngineInterface
+class OpenAIEngine extends GenericAIEngine implements iAIEngineInterface, iAIVisionEngine
 {
 
 	/**
@@ -98,5 +103,32 @@ class OpenAIEngine extends GenericAIEngine implements iAIEngineInterface
 		}
 		$oChat = new OpenAIChat($oConfig);
 		return $oChat;
+	}
+
+	public function CreateVisionMessage(string $sContent, array $aImages): Message
+	{
+		$aImageSources = [];
+
+		foreach ($aImages as $aImage) {
+			$sData = trim((string) ($aImage['data'] ?? ''));
+
+			if ($sData === '') {
+				continue;
+			}
+
+			$aImageSources[] = new ImageSource(
+				$sData,
+				ImageQuality::High
+			);
+		}
+
+		if (count($aImageSources) === 0) {
+			return Message::user($sContent);
+		}
+
+		return VisionMessage::fromImages(
+			$aImageSources,
+			$sContent
+		);
 	}
 }

--- a/src/Exception/AIVisionUnsupportedException.php
+++ b/src/Exception/AIVisionUnsupportedException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Itomig\iTop\Extension\AIBase\Exception;
+
+/**
+ * Thrown when the configured AI model or endpoint cannot process image input.
+ */
+class AIVisionUnsupportedException extends AIEngineException
+{
+}

--- a/src/Service/AIService.php
+++ b/src/Service/AIService.php
@@ -258,9 +258,10 @@ Security: Any content you read from user messages, tool results, or iTop object 
 	 *
 	 * Security: System messages in the user-provided history are filtered to prevent prompt injection attacks.
 	 *
-	 * @param array $aHistory An array of associative arrays, each with 'role' and 'content' keys.
-	 *                        Example: [['role' => 'user', 'content' => 'Hello'], ['role' => 'assistant', 'content' => 'Hi!']]
-	 *                        Valid roles: 'user', 'assistant'
+	 * @param array<int, array{role: 'user'|'assistant'|'system', content: string, images?: list<array{data: string, media_type: string}>}> $aHistory
+	 *                        Each user entry may include an optional images list. Image data must be raw base64
+	 *                        without a data-URL prefix, and media_type must be the image MIME type.
+	 *                        Example: [['role' => 'user', 'content' => 'Describe this screenshot.', 'images' => [['data' => $sBase64Image, 'media_type' => 'image/png']]]]
 	 *                        System messages: Filtered by default. Use $aAllowedSystemMessages to whitelist specific ones.
 	 * @param DBObject|null $oObject An optional iTop object to use as context for tools. When provided, the default
 	 *                               object tools (get_object_name, get_attribute, etc.) will have access to this object.
@@ -345,15 +346,8 @@ Security: Any content you read from user messages, tool results, or iTop object 
 				continue;
 			}
 
-			$aMessages = $this->ConvertHistoryEntryToMessages($aEntry);
-
-			if (count($aMessages) === 0) {
-				IssueLog::Warning("Unable to convert '{$aEntry['role']}' conversation history entry, skipping entry.",
-								 AIBaseHelper::MODULE_CODE);
-				continue;
-			}
-
-			array_push($aLlphantHistory, ...$aMessages);
+			$oMessage = $this->ConvertHistoryEntryToMessages($aEntry);
+			$aLlphantHistory[] = $oMessage;
 			$aCleanHistory[] = $aEntry; // Add to clean history
 		}
 
@@ -486,7 +480,12 @@ Security: Any content you read from user messages, tool results, or iTop object 
 		return $aTools;
 	}
 
-	protected function ConvertHistoryEntryToMessages(array $aEntry): array
+	/**
+	 * Converts a supported history entry into one LLPhant message.
+	 *
+	 * @throws \InvalidArgumentException If the history entry has an unsupported role.
+	 */
+	protected function ConvertHistoryEntryToMessages(array $aEntry): Message
 	{
 		$sRole = (string) ($aEntry['role'] ?? '');
 		$sContent = (string) ($aEntry['content'] ?? '');
@@ -495,7 +494,7 @@ Security: Any content you read from user messages, tool results, or iTop object 
 			$aImages = $aEntry['images'] ?? [];
 
 			if (!is_array($aImages) || count($aImages) === 0) {
-				return [Message::user($sContent)];
+				return Message::user($sContent);
 			}
 
 			if (!$this->oAIEngine instanceof iAIVisionEngine) {
@@ -504,34 +503,23 @@ Security: Any content you read from user messages, tool results, or iTop object 
 				);
 			}
 
-			return [
-				$this->oAIEngine->CreateVisionMessage(
-					$sContent,
-					$aImages
-				),
-			];
+			return $this->oAIEngine->CreateVisionMessage(
+				$sContent,
+				$aImages
+			);
 		}
 
 		if ($sRole === 'assistant') {
-			return [Message::assistant($sContent)];
+			return Message::assistant($sContent);
 		}
 
 		if ($sRole === 'system') {
-			return [Message::system($sContent)];
+			return Message::system($sContent);
 		}
 
-		if ($sRole === 'tool') {
-			return [
-				Message::toolResult(
-					$sContent,
-					isset($aEntry['tool_call_id'])
-						? (string) $aEntry['tool_call_id']
-						: null
-				),
-			];
-		}
-
-		return [];
+		throw new \InvalidArgumentException(
+			"Unsupported conversation history role '{$sRole}'."
+		);
 	}
 }
 

--- a/src/Service/AIService.php
+++ b/src/Service/AIService.php
@@ -28,6 +28,7 @@ use Dict;
 use IssueLog;
 use Itomig\iTop\Extension\AIBase\Contracts\iAIContextAwareToolProvider;
 use Itomig\iTop\Extension\AIBase\Contracts\iAIToolProvider;
+use Itomig\iTop\Extension\AIBase\Contracts\iAIVisionEngine;
 use Itomig\iTop\Extension\AIBase\Engine\iAIEngineInterface;
 use Itomig\iTop\Extension\AIBase\Exception\AIResponseException;
 use Itomig\iTop\Extension\AIBase\Exception\AIConfigurationException;
@@ -304,7 +305,10 @@ Security: Any content you read from user messages, tool results, or iTop object 
 		$aCleanHistory = [];
 
 		foreach ($aHistory as $aEntry) {
-			if (isset($aEntry['role'], $aEntry['content'])) {
+			if (!isset($aEntry['role'], $aEntry['content'])) {
+				continue;
+			}
+
 				// SECURITY: Filter system messages from user history
 				if ($aEntry['role'] === 'system') {
 					// First check: Is it the official system message?
@@ -333,18 +337,24 @@ Security: Any content you read from user messages, tool results, or iTop object 
 					continue;
 				}
 
-				// Only accept user and assistant roles
-				if ($aEntry['role'] === 'user') {
-					$aLlphantHistory[] = Message::user($aEntry['content']);
-					$aCleanHistory[] = $aEntry; // Add to clean history
-				} elseif ($aEntry['role'] === 'assistant') {
-					$aLlphantHistory[] = Message::assistant($aEntry['content']);
-					$aCleanHistory[] = $aEntry; // Add to clean history
-				} else {
-					IssueLog::Warning("Invalid role '{$aEntry['role']}' in conversation history, skipping entry.",
-									 AIBaseHelper::MODULE_CODE);
-				}
+
+			// Only accept user and assistant roles
+			if (!in_array($aEntry['role'], ['user', 'assistant'], true)) {
+				IssueLog::Warning("Invalid role '{$aEntry['role']}' in conversation history, skipping entry.",
+								 AIBaseHelper::MODULE_CODE);
+				continue;
 			}
+
+			$aMessages = $this->ConvertHistoryEntryToMessages($aEntry);
+
+			if (count($aMessages) === 0) {
+				IssueLog::Warning("Unable to convert '{$aEntry['role']}' conversation history entry, skipping entry.",
+								 AIBaseHelper::MODULE_CODE);
+				continue;
+			}
+
+			array_push($aLlphantHistory, ...$aMessages);
+			$aCleanHistory[] = $aEntry; // Add to clean history
 		}
 
 		// 5. Call the engine with the sanitized history and tools (multi-step tool loop)
@@ -474,6 +484,54 @@ Security: Any content you read from user messages, tool results, or iTop object 
 			$aTools = array_merge($aTools, $this->aContextDependentTools);
 		}
 		return $aTools;
+	}
+
+	protected function ConvertHistoryEntryToMessages(array $aEntry): array
+	{
+		$sRole = (string) ($aEntry['role'] ?? '');
+		$sContent = (string) ($aEntry['content'] ?? '');
+
+		if ($sRole === 'user') {
+			$aImages = $aEntry['images'] ?? [];
+
+			if (!is_array($aImages) || count($aImages) === 0) {
+				return [Message::user($sContent)];
+			}
+
+			if (!$this->oAIEngine instanceof iAIVisionEngine) {
+				throw new AIConfigurationException(
+					'The configured AI engine does not support image input.'
+				);
+			}
+
+			return [
+				$this->oAIEngine->CreateVisionMessage(
+					$sContent,
+					$aImages
+				),
+			];
+		}
+
+		if ($sRole === 'assistant') {
+			return [Message::assistant($sContent)];
+		}
+
+		if ($sRole === 'system') {
+			return [Message::system($sContent)];
+		}
+
+		if ($sRole === 'tool') {
+			return [
+				Message::toolResult(
+					$sContent,
+					isset($aEntry['tool_call_id'])
+						? (string) $aEntry['tool_call_id']
+						: null
+				),
+			];
+		}
+
+		return [];
 	}
 }
 

--- a/tests/php-unit-tests/unitary-tests/GenericAIEngineExceptionTest.php
+++ b/tests/php-unit-tests/unitary-tests/GenericAIEngineExceptionTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Itomig\iTop\AiBase\Test;
+
+use Combodo\iTop\Test\UnitTest\ItopTestCase;
+use Itomig\iTop\Extension\AIBase\Engine\GenericAIEngine;
+use Itomig\iTop\Extension\AIBase\Engine\iAIEngineInterface;
+use Itomig\iTop\Extension\AIBase\Exception\AIContextWindowException;
+use Itomig\iTop\Extension\AIBase\Exception\AIEngineException;
+use Itomig\iTop\Extension\AIBase\Exception\AINetworkException;
+use Itomig\iTop\Extension\AIBase\Exception\AIVisionUnsupportedException;
+use LLPhant\Chat\ChatInterface;
+use LLPhant\Exception\HttpException;
+
+class GenericAIEngineExceptionTest extends ItopTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->RequireOnceItopFile('/env-production/itomig-ai-base/vendor/autoload.php');
+	}
+
+	public function testVisionCapabilityErrorsAreClassifiedSeparately(): void
+	{
+		$aCases = [
+			[404, 'HTTP error from AI engine (404): {"error":{"message":"No endpoints found that support image input","code":404}}'],
+			[400, 'No available endpoints support vision input'],
+			[400, 'Invalid content type. image_url is only supported by certain models.'],
+			[400, 'Image input is only supported for Pixtral models.'],
+			[400, 'This model does not support images'],
+			[400, 'Fireworks AI model does not support image inputs. Use a Fireworks vision model.'],
+			[400, 'The selected model is not multimodal and cannot process visual input.'],
+			[400, 'The model does not have vision capability'],
+			[400, 'Unsupported image input'],
+			[400, 'Image inputs are not compatible with this model'],
+			[400, 'Unsupported input type: image'],
+		];
+
+		foreach ($aCases as [$iCode, $sMessage]) {
+			$oException = $this->buildEngine()->classifyForTest(new HttpException($sMessage, $iCode));
+
+			static::assertInstanceOf(AIVisionUnsupportedException::class, $oException, $sMessage);
+			static::assertSame($iCode, $oException->getCode());
+			static::assertStringContainsString('vision-capable model', $oException->getMessage());
+		}
+	}
+
+	public function testContextWindowErrorsRemainContextErrors(): void
+	{
+		$aMessages = [
+			'maximum context length exceeded',
+			'maximum request size exceeded',
+			'Image exceeds the maximum size',
+		];
+
+		foreach ($aMessages as $sMessage) {
+			$oException = $this->buildEngine()->classifyForTest(new HttpException($sMessage, 400));
+
+			static::assertInstanceOf(AIContextWindowException::class, $oException);
+		}
+	}
+
+	public function testUnrelatedNotFoundErrorsRemainNetworkErrors(): void
+	{
+		$oException = $this->buildEngine()->classifyForTest(new HttpException('model endpoint not found', 404));
+
+		static::assertInstanceOf(AINetworkException::class, $oException);
+		static::assertNotInstanceOf(AIVisionUnsupportedException::class, $oException);
+	}
+
+	public function testImageFormatAndUrlErrorsRemainNetworkErrors(): void
+	{
+		$aMessages = [
+			'Unsupported image format: image/png',
+			'Invalid image URL',
+		];
+
+		foreach ($aMessages as $sMessage) {
+			$oException = $this->buildEngine()->classifyForTest(new HttpException($sMessage, 400));
+
+			static::assertInstanceOf(AINetworkException::class, $oException);
+			static::assertNotInstanceOf(AIVisionUnsupportedException::class, $oException);
+		}
+	}
+
+	private function buildEngine(): GenericAIEngine
+	{
+		return new class extends GenericAIEngine {
+			public function __construct()
+			{
+				parent::__construct('', '', '');
+			}
+
+			public static function GetEngineName(): string
+			{
+				return 'ExceptionTestEngine';
+			}
+
+			public static function GetEngine(array $configuration): iAIEngineInterface
+			{
+				throw new \LogicException('Not used in this test.');
+			}
+
+			public function GetCompletion(string $message, string $systemInstruction = ''): string
+			{
+				throw new \LogicException('Not used in this test.');
+			}
+
+			protected function createChatInstance(): ChatInterface
+			{
+				throw new \LogicException('Not used in this test.');
+			}
+
+			public function classifyForTest(HttpException $oException): AIEngineException
+			{
+				return $this->classifyHttpException($oException);
+			}
+		};
+	}
+}

--- a/tests/php-unit-tests/unitary-tests/ImageInputConversationTest.php
+++ b/tests/php-unit-tests/unitary-tests/ImageInputConversationTest.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Unit tests for image input conversation support.
+ *
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Itomig\iTop\AiBase\Test;
+
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use Itomig\iTop\Extension\AIBase\Contracts\iAIVisionEngine;
+use Itomig\iTop\Extension\AIBase\Engine\iAIEngineInterface;
+use Itomig\iTop\Extension\AIBase\Exception\AIConfigurationException;
+use Itomig\iTop\Extension\AIBase\Service\AIService;
+use LLPhant\Chat\Enums\ChatRole;
+use LLPhant\Chat\Message;
+
+class ImageInputConversationTest extends ItopDataTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->RequireOnceItopFile('/env-production/itomig-ai-base/vendor/autoload.php');
+	}
+
+	public function testContinueConversationConvertsUserImagesThroughVisionEngine(): void
+	{
+		$aImages = [
+			[
+				'data' => base64_encode('png-bytes'),
+				'media_type' => 'image/png',
+			],
+			[
+				'data' => base64_encode('jpeg-bytes'),
+				'media_type' => 'image/jpeg',
+			],
+		];
+
+		$oEngine = new class($this, $aImages) implements iAIEngineInterface, iAIVisionEngine {
+			public function __construct(
+				private ImageInputConversationTest $oTest,
+				private array $aExpectedImages
+			) {
+			}
+
+			public static function GetEngineName(): string
+			{
+				return 'VisionTestEngine';
+			}
+
+			public static function GetEngine(array $configuration): iAIEngineInterface
+			{
+				throw new \LogicException('Not used in this test.');
+			}
+
+			public function GetCompletion(string $message, string $systemInstruction = ''): string
+			{
+				throw new \LogicException('Not used in this test.');
+			}
+
+			public function CreateVisionMessage(string $sContent, array $aImages): Message
+			{
+				$this->oTest::assertSame('Describe these screenshots.', $sContent);
+				$this->oTest::assertSame($this->aExpectedImages, $aImages);
+
+				return Message::user('vision:'.$sContent);
+			}
+
+			public function GetNextTurn(array $aHistory, array $aTools = []): string|array
+			{
+				$this->oTest::assertCount(2, $aHistory);
+				$this->oTest::assertSame(ChatRole::System, $aHistory[0]->role);
+				$this->oTest::assertSame(ChatRole::User, $aHistory[1]->role);
+				$this->oTest::assertSame('vision:Describe these screenshots.', $aHistory[1]->content);
+
+				return 'The screenshots show an iTop ticket form.';
+			}
+		};
+
+		$oAIService = new AIService($oEngine);
+		$aResult = $oAIService->ContinueConversation([
+			[
+				'role' => 'user',
+				'content' => 'Describe these screenshots.',
+				'images' => $aImages,
+			],
+		]);
+
+		static::assertSame('The screenshots show an iTop ticket form.', $aResult['response']);
+		static::assertSame($aImages, $aResult['history'][0]['images']);
+	}
+
+	public function testContinueConversationRejectsImagesWhenEngineDoesNotSupportVision(): void
+	{
+		$oEngine = $this->createMock(iAIEngineInterface::class);
+		$oEngine->expects(static::never())->method('GetNextTurn');
+
+		$oAIService = new AIService($oEngine);
+
+		$this->expectException(AIConfigurationException::class);
+		$this->expectExceptionMessage('The configured AI engine does not support image input.');
+
+		$oAIService->ContinueConversation([
+			[
+				'role' => 'user',
+				'content' => 'Describe this screenshot.',
+				'images' => [
+					[
+						'data' => base64_encode('png-bytes'),
+						'media_type' => 'image/png',
+					],
+				],
+			],
+		]);
+	}
+
+	public function testContinueConversationTreatsMissingEmptyAndNonArrayImagesAsText(): void
+	{
+		$oEngine = $this->createMock(iAIEngineInterface::class);
+		$oEngine->expects(static::once())
+			->method('GetNextTurn')
+			->willReturnCallback(function (array $aHistory, array $aTools): string {
+				static::assertCount(4, $aHistory);
+				static::assertSame(ChatRole::System, $aHistory[0]->role);
+				static::assertSame(ChatRole::User, $aHistory[1]->role);
+				static::assertSame('No images', $aHistory[1]->content);
+				static::assertSame(ChatRole::User, $aHistory[2]->role);
+				static::assertSame('Empty images', $aHistory[2]->content);
+				static::assertSame(ChatRole::User, $aHistory[3]->role);
+				static::assertSame('Non-array images', $aHistory[3]->content);
+
+				return 'Text-only response';
+			});
+
+		$oAIService = new AIService($oEngine);
+		$aResult = $oAIService->ContinueConversation([
+			[
+				'role' => 'user',
+				'content' => 'No images',
+			],
+			[
+				'role' => 'user',
+				'content' => 'Empty images',
+				'images' => [],
+			],
+			[
+				'role' => 'user',
+				'content' => 'Non-array images',
+				'images' => 'not-an-array',
+			],
+		]);
+
+		static::assertSame('Text-only response', $aResult['response']);
+		static::assertCount(4, $aResult['history']);
+	}
+
+	public function testAssistantImagesRemainNormalAssistantMessages(): void
+	{
+		$oEngine = $this->createMock(iAIEngineInterface::class);
+		$oEngine->expects(static::once())
+			->method('GetNextTurn')
+			->willReturnCallback(function (array $aHistory, array $aTools): string {
+				static::assertCount(2, $aHistory);
+				static::assertSame(ChatRole::Assistant, $aHistory[1]->role);
+				static::assertSame('Assistant image description', $aHistory[1]->content);
+
+				return 'Next response';
+			});
+
+		$oAIService = new AIService($oEngine);
+		$aResult = $oAIService->ContinueConversation([
+			[
+				'role' => 'assistant',
+				'content' => 'Assistant image description',
+				'images' => [
+					[
+						'data' => base64_encode('ignored'),
+						'media_type' => 'image/png',
+					],
+				],
+			],
+		]);
+
+		static::assertSame('Next response', $aResult['response']);
+	}
+}

--- a/tests/php-unit-tests/unitary-tests/VisionEngineMessageTest.php
+++ b/tests/php-unit-tests/unitary-tests/VisionEngineMessageTest.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Unit tests for provider-specific vision message construction.
+ *
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Itomig\iTop\AiBase\Test;
+
+use Combodo\iTop\Test\UnitTest\ItopTestCase;
+use Itomig\iTop\Extension\AIBase\Contracts\iAIVisionEngine;
+use Itomig\iTop\Extension\AIBase\Engine\AnthropicAIEngine;
+use Itomig\iTop\Extension\AIBase\Engine\MistralAIEngine;
+use Itomig\iTop\Extension\AIBase\Engine\OllamaAIEngine;
+use Itomig\iTop\Extension\AIBase\Engine\OpenAIEngine;
+use LLPhant\Chat\Anthropic\AnthropicVisionMessage;
+use LLPhant\Chat\Enums\ChatRole;
+use LLPhant\Chat\Message;
+use LLPhant\Chat\Vision\VisionMessage;
+
+class VisionEngineMessageTest extends ItopTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->RequireOnceItopFile('/env-production/itomig-ai-base/vendor/autoload.php');
+	}
+
+	public function testOnlyOpenAIAndAnthropicEnginesAdvertiseVisionSupport(): void
+	{
+		$oOpenAIEngine = OpenAIEngine::GetEngine(['api_key' => 'test-api-key']);
+		$oAnthropicEngine = AnthropicAIEngine::GetEngine(['api_key' => 'test-api-key']);
+		$oMistralEngine = MistralAIEngine::GetEngine(['api_key' => 'test-api-key']);
+		$oOllamaEngine = OllamaAIEngine::GetEngine([]);
+
+		static::assertInstanceOf(iAIVisionEngine::class, $oOpenAIEngine);
+		static::assertInstanceOf(iAIVisionEngine::class, $oAnthropicEngine);
+		static::assertNotInstanceOf(iAIVisionEngine::class, $oMistralEngine);
+		static::assertNotInstanceOf(iAIVisionEngine::class, $oOllamaEngine);
+	}
+
+	public function testOpenAIEngineCreatesVisionMessageForAllSupportedImageFormats(): void
+	{
+		$aImages = [
+			[
+				'data' => $this->validImageData('png'),
+				'media_type' => 'image/png',
+			],
+			[
+				'data' => $this->validImageData('jpeg'),
+				'media_type' => 'image/jpeg',
+			],
+			[
+				'data' => $this->validImageData('gif'),
+				'media_type' => 'image/gif',
+			],
+			[
+				'data' => $this->validImageData('webp'),
+				'media_type' => 'image/webp',
+			],
+		];
+
+		$oMessage = OpenAIEngine::GetEngine(['api_key' => 'test-api-key'])
+			->CreateVisionMessage('Describe these images.', $aImages);
+
+		static::assertInstanceOf(VisionMessage::class, $oMessage);
+		static::assertSame(ChatRole::User, $oMessage->role);
+		static::assertSame('Describe these images.', $oMessage->content);
+		static::assertCount(4, $oMessage->images);
+
+		$aSerialized = json_decode(json_encode($oMessage, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+		static::assertSame('user', $aSerialized['role']);
+		static::assertSame([
+			'type' => 'text',
+			'text' => 'Describe these images.',
+		], $aSerialized['content'][0]);
+
+		foreach ($aImages as $iIndex => $aImage) {
+			$aImageContent = $aSerialized['content'][$iIndex + 1];
+			static::assertSame('image_url', $aImageContent['type']);
+			static::assertSame(
+				'data:'.$aImage['media_type'].';base64,'.$aImage['data'],
+				$aImageContent['image_url']['url']
+			);
+			static::assertSame('high', $aImageContent['image_url']['detail']);
+		}
+	}
+
+	public function testOpenAIEngineSkipsEmptyImagesAndFallsBackToTextWhenNoneRemain(): void
+	{
+		$oMessage = OpenAIEngine::GetEngine(['api_key' => 'test-api-key'])
+			->CreateVisionMessage('Text only.', [
+				[],
+				['data' => ''],
+				['data' => '   ', 'media_type' => 'image/png'],
+			]);
+
+		static::assertInstanceOf(Message::class, $oMessage);
+		static::assertNotInstanceOf(VisionMessage::class, $oMessage);
+		static::assertSame(ChatRole::User, $oMessage->role);
+		static::assertSame('Text only.', $oMessage->content);
+	}
+
+	public function testOpenAIEngineKeepsValidImagesWhenEmptyEntriesAreMixedIn(): void
+	{
+		$sImageData = $this->validImageData('png');
+		$oMessage = OpenAIEngine::GetEngine(['api_key' => 'test-api-key'])
+			->CreateVisionMessage('One valid image.', [
+				['data' => ''],
+				['data' => $sImageData, 'media_type' => 'image/png'],
+				[],
+			]);
+
+		static::assertInstanceOf(VisionMessage::class, $oMessage);
+		static::assertCount(1, $oMessage->images);
+		$aSerialized = json_decode(json_encode($oMessage, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+		static::assertSame('data:image/png;base64,'.$sImageData, $aSerialized['content'][1]['image_url']['url']);
+	}
+
+	public function testOpenAIEngineRejectsNonImageBase64Data(): void
+	{
+		$this->expectException(\InvalidArgumentException::class);
+
+		OpenAIEngine::GetEngine(['api_key' => 'test-api-key'])
+			->CreateVisionMessage('Invalid image.', [
+				[
+					'data' => base64_encode('this is not an image'),
+					'media_type' => 'image/png',
+				],
+			]);
+	}
+
+	public function testAnthropicEngineCreatesVisionMessageWithProviderContentBlocks(): void
+	{
+		$aImages = [
+			[
+				'data' => $this->validImageData('png'),
+				'media_type' => 'image/png',
+			],
+			[
+				'data' => $this->validImageData('jpeg'),
+				'media_type' => 'image/jpeg',
+			],
+		];
+
+		$oMessage = AnthropicAIEngine::GetEngine(['api_key' => 'test-api-key'])
+			->CreateVisionMessage('Describe these images.', $aImages);
+
+		static::assertInstanceOf(AnthropicVisionMessage::class, $oMessage);
+		static::assertSame(ChatRole::User, $oMessage->role);
+		static::assertSame('Describe these images.', $oMessage->content);
+		static::assertSame([
+			[
+				'type' => 'image',
+				'source' => [
+					'type' => 'base64',
+					'media_type' => 'image/png',
+					'data' => $aImages[0]['data'],
+				],
+			],
+			[
+				'type' => 'image',
+				'source' => [
+					'type' => 'base64',
+					'media_type' => 'image/jpeg',
+					'data' => $aImages[1]['data'],
+				],
+			],
+			[
+				'type' => 'text',
+				'text' => 'Describe these images.',
+			],
+		], $oMessage->contentsArray);
+	}
+
+	public function testAnthropicEngineSkipsInvalidEntriesAndKeepsValidImages(): void
+	{
+		$sImageData = $this->validImageData('png');
+		$oMessage = AnthropicAIEngine::GetEngine(['api_key' => 'test-api-key'])
+			->CreateVisionMessage('Keep the valid image.', [
+				'not-an-array',
+				[],
+				['data' => '', 'media_type' => 'image/png'],
+				['data' => $sImageData, 'media_type' => 'image/tiff'],
+				['data' => 'not-base64!', 'media_type' => 'image/png'],
+				['data' => $sImageData, 'media_type' => 'image/png'],
+			]);
+
+		static::assertInstanceOf(AnthropicVisionMessage::class, $oMessage);
+		static::assertCount(2, $oMessage->contentsArray);
+		static::assertSame('image/png', $oMessage->contentsArray[0]['source']['media_type']);
+		static::assertSame($sImageData, $oMessage->contentsArray[0]['source']['data']);
+		static::assertSame('text', $oMessage->contentsArray[1]['type']);
+	}
+
+	public function testAnthropicEngineFallsBackToTextWhenAllImagesAreInvalid(): void
+	{
+		$oMessage = AnthropicAIEngine::GetEngine(['api_key' => 'test-api-key'])
+			->CreateVisionMessage('Text only.', [
+				'not-an-array',
+				['data' => '', 'media_type' => 'image/png'],
+				['data' => base64_encode('not an image'), 'media_type' => 'image/tiff'],
+				['data' => 'not-base64!', 'media_type' => 'image/png'],
+			]);
+
+		static::assertInstanceOf(Message::class, $oMessage);
+		static::assertNotInstanceOf(AnthropicVisionMessage::class, $oMessage);
+		static::assertSame(ChatRole::User, $oMessage->role);
+		static::assertSame('Text only.', $oMessage->content);
+	}
+
+	private function validImageData(string $sFormat): string
+	{
+		$sBytes = match ($sFormat) {
+			'png' => chr(0x89).'PNG'.chr(13).chr(10).chr(26).chr(10).str_repeat(chr(0), 12),
+			'jpeg' => chr(255).chr(216).chr(255).chr(224).str_repeat(chr(0), 12),
+			'gif' => 'GIF89a'.str_repeat(chr(0), 12),
+			'webp' => 'RIFF'.str_repeat(chr(0), 4).'WEBP'.str_repeat(chr(0), 8),
+			default => throw new \InvalidArgumentException('Unsupported test image format.'),
+		};
+
+		return base64_encode($sBytes);
+	}
+}

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -123,6 +123,7 @@ return array(
     'Http\\Message\\MultipartStream\\MultipartStreamBuilder' => $vendorDir . '/php-http/multipart-stream-builder/src/MultipartStreamBuilder.php',
     'Itomig\\iTop\\Extension\\AIBase\\Contracts\\iAIContextAwareToolProvider' => $baseDir . '/src/Contracts/iAIContextAwareToolProvider.php',
     'Itomig\\iTop\\Extension\\AIBase\\Contracts\\iAIToolProvider' => $baseDir . '/src/Contracts/iAIToolProvider.php',
+    'Itomig\\iTop\\Extension\\AIBase\\Contracts\\iAIVisionEngine' => $baseDir . '/src/Contracts/iAIVisionEngine.php',
     'Itomig\\iTop\\Extension\\AIBase\\Engine\\AnthropicAIEngine' => $baseDir . '/src/Engine/AnthropicAIEngine.php',
     'Itomig\\iTop\\Extension\\AIBase\\Engine\\Embedding\\GenericEmbeddingEngine' => $baseDir . '/src/Engine/Embedding/GenericEmbeddingEngine.php',
     'Itomig\\iTop\\Extension\\AIBase\\Engine\\Embedding\\OpenAICompatibleGenerator' => $baseDir . '/src/Engine/Embedding/OpenAICompatibleGenerator.php',

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -141,6 +141,7 @@ return array(
     'Itomig\\iTop\\Extension\\AIBase\\Exception\\AINetworkException' => $baseDir . '/src/Exception/AINetworkException.php',
     'Itomig\\iTop\\Extension\\AIBase\\Exception\\AIRateLimitException' => $baseDir . '/src/Exception/AIRateLimitException.php',
     'Itomig\\iTop\\Extension\\AIBase\\Exception\\AIResponseException' => $baseDir . '/src/Exception/AIResponseException.php',
+    'Itomig\\iTop\\Extension\\AIBase\\Exception\\AIVisionUnsupportedException' => $baseDir . '/src/Exception/AIVisionUnsupportedException.php',
     'Itomig\\iTop\\Extension\\AIBase\\Helper\\AIBaseHelper' => $baseDir . '/src/Helper/AIBaseHelper.php',
     'Itomig\\iTop\\Extension\\AIBase\\Helper\\AIObjectTools' => $baseDir . '/src/Helper/AIObjectTools.php',
     'Itomig\\iTop\\Extension\\AIBase\\Helper\\AISystemTools' => $baseDir . '/src/Helper/AISystemTools.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -258,6 +258,7 @@ class ComposerStaticInitd8be68bed68b2e666ec5f78f725945c1
         'Http\\Message\\MultipartStream\\MultipartStreamBuilder' => __DIR__ . '/..' . '/php-http/multipart-stream-builder/src/MultipartStreamBuilder.php',
         'Itomig\\iTop\\Extension\\AIBase\\Contracts\\iAIContextAwareToolProvider' => __DIR__ . '/../..' . '/src/Contracts/iAIContextAwareToolProvider.php',
         'Itomig\\iTop\\Extension\\AIBase\\Contracts\\iAIToolProvider' => __DIR__ . '/../..' . '/src/Contracts/iAIToolProvider.php',
+        'Itomig\\iTop\\Extension\\AIBase\\Contracts\\iAIVisionEngine' => __DIR__ . '/../..' . '/src/Contracts/iAIVisionEngine.php',
         'Itomig\\iTop\\Extension\\AIBase\\Engine\\AnthropicAIEngine' => __DIR__ . '/../..' . '/src/Engine/AnthropicAIEngine.php',
         'Itomig\\iTop\\Extension\\AIBase\\Engine\\Embedding\\GenericEmbeddingEngine' => __DIR__ . '/../..' . '/src/Engine/Embedding/GenericEmbeddingEngine.php',
         'Itomig\\iTop\\Extension\\AIBase\\Engine\\Embedding\\OpenAICompatibleGenerator' => __DIR__ . '/../..' . '/src/Engine/Embedding/OpenAICompatibleGenerator.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -276,6 +276,7 @@ class ComposerStaticInitd8be68bed68b2e666ec5f78f725945c1
         'Itomig\\iTop\\Extension\\AIBase\\Exception\\AINetworkException' => __DIR__ . '/../..' . '/src/Exception/AINetworkException.php',
         'Itomig\\iTop\\Extension\\AIBase\\Exception\\AIRateLimitException' => __DIR__ . '/../..' . '/src/Exception/AIRateLimitException.php',
         'Itomig\\iTop\\Extension\\AIBase\\Exception\\AIResponseException' => __DIR__ . '/../..' . '/src/Exception/AIResponseException.php',
+        'Itomig\\iTop\\Extension\\AIBase\\Exception\\AIVisionUnsupportedException' => __DIR__ . '/../..' . '/src/Exception/AIVisionUnsupportedException.php',
         'Itomig\\iTop\\Extension\\AIBase\\Helper\\AIBaseHelper' => __DIR__ . '/../..' . '/src/Helper/AIBaseHelper.php',
         'Itomig\\iTop\\Extension\\AIBase\\Helper\\AIObjectTools' => __DIR__ . '/../..' . '/src/Helper/AIObjectTools.php',
         'Itomig\\iTop\\Extension\\AIBase\\Helper\\AISystemTools' => __DIR__ . '/../..' . '/src/Helper/AISystemTools.php',


### PR DESCRIPTION
## Summary

- Add image input support to multi-turn conversations through user history entries.
- Add the `iAIVisionEngine` contract for vision-capable engines.
- Add OpenAI and Anthropic vision-message support.
- Reject image input locally for engines without vision support.
- Document the image payload contract in PHPDoc and README files.
- Add comprehensive tests for image routing, fallbacks, invalid input, supported formats, provider payloads, and tool-message conversion.

## Image input format

```php
[
    'role' => 'user',
    'content' => 'Describe this screenshot.',
    'images' => [
        [
            'data' => $sBase64ImageData,
            'media_type' => 'image/png',
        ],
    ],
]